### PR TITLE
add code of conduct

### DIFF
--- a/coc/index.md
+++ b/coc/index.md
@@ -1,0 +1,21 @@
+---
+layout: page
+---
+
+# Code of Conduct
+
+The organizers are committed to making this conference a productive, enjoyable and safe environment for everyone, regardless of ethnic origin, citizenship, language, gender, sexual orientation, disability, physical appearance, body size, race, age or religion. We will not tolerate harassment of participants in any form. We ask that all participants follow the following expected standards of behavior:
+
+- Be professional, considerate, respectful and collaborative when interacting with your colleagues.
+- Do not create an intimidating, hostile, or offensive environment for any of the participants.
+- Do not engage in physical or verbal abuse of anyone.
+- Do not engage in harassment, intimidation or discrimination in any form.
+- Speak up if you witness unacceptable behaviour and/or report it afterward (see below).
+
+## Definition of harassment
+
+In general, harassment is a conduct that exerts unwelcome pressure or intimidation. This conduct includes, but is not limited to: epithets, slurs or negative stereotyping; threatening, intimidating or hostile acts; denigrating jokes and display or circulation of written or graphic material that denigrates or shows hostility or aversion toward an individual or group. Particularly serious is the sexual harassment that refers to unwelcome sexual advances, requests for sexual favours, and other verbal or physical conduct of a sexual nature. Because of the wide international nature of the astronomical community, it is important to realize that behavior and language that are welcome/acceptable in one particular cultural environment may be unwelcome/offensive to another. Consequently, individuals must use discretion to ensure that their words and actions communicate respect for others. This is especially important for those in positions of authority since individuals with lower rank or status may be reluctant to express their objections or discomfort regarding unwelcome behavior.
+
+Participants asked to stop any inappropriate behavior from conference organizers are expected to comply immediately. Attendees violating these rules may be asked to leave the event at the sole discretion of the organizers without a refund of any charge. Any participant who wishes to report a violation of this policy is encouraged to speak, in confidence, to the LOC in person or by email (<tasc7@hawaii.edu>).
+
+The organizers support the communication and discussion of science in all formats. Information, including original data, slides, or other visual representations, may be summarized and discussed by attendees and science writers via blogs and other social media formats. However, we ask that this be done respectfully and that permission be obtained from the presenter before reproducing any visual materials.


### PR DESCRIPTION
text of coc copied from registration form — generally useful to have accessible outside the form